### PR TITLE
Remove temporary file after run

### DIFF
--- a/lib/generators/generator.js
+++ b/lib/generators/generator.js
@@ -7,6 +7,7 @@
 
 'use strict'
 
+const fs = require('fs')
 const co = require('co')
 const path = require('path')
 const svgpng = require('svgpng')
@@ -72,9 +73,10 @@ Generator.prototype = {
               height: height
             },
             silent: true
-          }, (err) =>
+          }, (err) => {
+            fs.unlink(tmpFile)
             err ? reject(err) : resolve()
-        )
+          })
       )
     })
   },


### PR DESCRIPTION
When fur is instructed to generate a png it generates a temporary file. This PR ensures that fur will clean that up once it's done with the run.

Cheers